### PR TITLE
[issue 6] Add commit command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,24 @@
 #!/usr/bin/env node
-import { handleCommandOrQuestion } from './src/commands.js';
 import { openEditor, setModel } from './src/utils.js';
+import { generateCommitMessage, askCommitConfirmationAndExecute } from './src/commands/commit.js';
+import { handleCommandOrQuestion } from './src/commands.js';
 
 // Capture command-line arguments.
 const args = process.argv.slice(2);
 
+// Capture /commit command
+if (args.includes('/commit')) {
+  const commitData = await generateCommitMessage();
+
+  if (!commitData) {
+    process.exit(1);
+  }
+
+  const { title, description } = commitData;
+  askCommitConfirmationAndExecute(title, description);
+
 // Capture command-line arguments.
-if (args.includes('--commands')) {
+} else if (args.includes('--commands')) {
   openEditor();
 
 // Check for the `--model` flag to set a specific model.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
   "packages": {
     "": {
       "name": "jarvis-sh",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^5.3.0",
         "inquirer": "^11.1.0",
         "ollama": "^0.5.9"
       },
@@ -264,6 +265,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chardet": {
@@ -685,6 +697,11 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
     },
     "chardet": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "chalk": "^5.3.0",
     "inquirer": "^11.1.0",
     "ollama": "^0.5.9"
   }

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -1,0 +1,109 @@
+import { execSync, exec } from 'child_process';
+import readline from 'readline';
+import chalk from 'chalk';
+import { askModel } from '../ollamaClient.js';
+import { readConfig } from '../utils.js';
+
+/**
+ * Function to get the staged diff in the Git repository.
+ * 
+ * @returns {string | null} - The Git diff of staged changes as a string, or null if an error occurs.
+ */
+async function getStagedDiff() {
+  try {
+    const diff = execSync('git diff --staged').toString();
+    return diff;
+  } catch (error) {
+    console.error('Error retrieving the diff:', error);
+    return null;
+  }
+}
+
+/**
+ * Function to generate a commit message based on the staged Git diff and the model's response.
+ * 
+ * @returns {Promise<{title: string, description: string} | false>} - A JSON with the title and description using conventional commits, or false if the process fails.
+ */
+export async function generateCommitMessage() {
+  const { model } = readConfig();
+  const diff = await getStagedDiff();
+  
+  if (!diff) {
+    console.log('There are no staged changes to commit.');
+    return false;
+  }
+
+  const message = `
+  Conventional Commits is a specification for writing consistent and meaningful commit messages. The structure of a conventional commit is as follows:
+  
+  <type>: <short description>
+  
+  - **type**: Specifies the category of the change. Common types are:
+    - 'feat': A new feature
+    - 'fix': A bug fix
+    - 'chore': Routine tasks or maintenance
+    - 'refactor': Code changes that don't affect functionality
+    - 'docs': Documentation-only changes
+    - 'test': Adding or updating tests
+    - 'style': Code style changes (e.g., formatting)
+  
+  ---
+  
+  Use the following git diff and give me the title and description for the commit using conventional commits:
+  
+  ${diff}
+  
+  Give me a JSON with only the title and description using conventional commits`.trim();
+  
+  const response = await askModel({
+    model,
+    messages: [{ role: 'user', content: message }],
+    format: 'json',
+  });
+
+  if (!response) {
+    console.error('Error generating the commit message.');
+    return false;
+  }
+
+  const { title, description } = JSON.parse(response);
+  return { title, description };
+}
+
+/**
+ * Function to prompt the user if they want to proceed with the commit and perform the commit if confirmed.
+ * 
+ * @param {string} title - The commit title.
+ * @param {string} description - The commit description.
+ */
+export function askCommitConfirmationAndExecute(title, description) {
+  console.log(`\nCommit message generated:`);
+  console.log(`${chalk.green('Title:')} ${title}`);
+  console.log(`${chalk.green('Description:')} ${description}`);
+  console.log(`Do you want to commit with this message? ${chalk.green('(y/n)')}`);
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.question('', (answer) => {
+    if (answer.toLowerCase() === 'y') {
+      const commitMessage = `${title}\n\n${description}`;
+      exec(`git commit -m "${commitMessage}"`, (error, stdout, stderr) => {
+        if (error) {
+          console.error(`Error committing: ${error.message}`);
+          return;
+        }
+        if (stderr) {
+          console.error(`stderr: ${stderr}`);
+          return;
+        }
+        console.log(`Commit completed: ${stdout}`);
+      });
+    } else {
+      console.log("Commit canceled.");
+    }
+    rl.close();
+  });
+}


### PR DESCRIPTION
This PR introduces the /commit command, which generates a conventional commit message based on the staged Git diff. It prompts the user for confirmation before committing and enhances the UX with colored console output using chalk.