### PR TITLE
Update link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jarvis Hello
 
 Jarvis-sh will provide an answer directly in the terminal.
 
-If you want to use the `?` symbol at the end of your questions to Jarvis, you need to apply the [following configuration](.doc/ZshUsers.md) in your terminal.
+If you want to use the `?` symbol at the end of your questions to Jarvis, you need to apply the [following configuration](doc/ZshUsers.md) in your terminal.
 
 ### Execute Commands
 


### PR DESCRIPTION
Fixes the path to Zsh configuration documentation in the README file.